### PR TITLE
Changed variable names in units module

### DIFF
--- a/orbkit/detci/ci_read/gamess.py
+++ b/orbkit/detci/ci_read/gamess.py
@@ -76,7 +76,7 @@ def gamess_tddft(fname,select_state=None,threshold=0.0,**kwargs):
         ci[-1].coeffs = []
         ci[-1].occ    = []
         ci[-1].info = {'state': thisline[2],
-                       'energy': float(thisline[-2])*ev2ha,
+                       'energy': float(thisline[-2])*ev_to_ha,
                        'fileinfo': filename,
                        'read_threshold': threshold,
                        'spin': 'Unknown',

--- a/orbkit/detci/ci_read/high_level.py
+++ b/orbkit/detci/ci_read/high_level.py
@@ -4,7 +4,7 @@ from copy import copy
 from orbkit.display import display
 from orbkit.qcinfo import QCinfo, CIinfo
 from orbkit.orbitals import MOClass
-from orbkit.units import ev2ha
+from orbkit.units import ev_to_ha
 
 from .tools import molpro_mo_order_ci
 from .psi4 import psi4_detci

--- a/orbkit/output/high_level.py
+++ b/orbkit/output/high_level.py
@@ -31,7 +31,7 @@ from os import path
 # Import orbkit modules
 from orbkit import grid, options
 from orbkit.display import display
-from orbkit.units import a02aa
+from orbkit.units import a0_to_aa
 
 from .amira import amira_creator
 from .cube import cube_creator

--- a/orbkit/output/pdb.py
+++ b/orbkit/output/pdb.py
@@ -1,6 +1,6 @@
 import numpy
 
-from orbkit.units import a02aa
+from orbkit.units import a0_to_aa
 
 def pdb_creator(geo_info,geo_spec,filename='new',charges=None,comments='',
     angstrom=True):
@@ -44,7 +44,7 @@ def pdb_creator(geo_info,geo_spec,filename='new',charges=None,comments='',
       string += ' '
     xyz = geo_spec[il]
     if angstrom:
-      xyz *= a02aa
+      xyz *= a0_to_aa
     string += '             %s %s %s        ' % (('%.9f' % xyz[0])[:7],
                                                  ('%.9f' % xyz[1])[:7],
                                                  ('%.9f' % xyz[2])[:7])

--- a/orbkit/output/xyz.py
+++ b/orbkit/output/xyz.py
@@ -31,7 +31,7 @@ def xyz_creator(geo_info,geo_spec,filename='new',mode='w',charges=None,comments=
     for i in range(3):
       xyz = geo_spec[il]
       if angstrom:
-        xyz *= a02aa
+        xyz *= a0_to_aa
       string += ' %22.15f'  % (xyz[i])
     if charges is not None:
       string += ' %22.15f'  % charges[il]

--- a/orbkit/qcinfo.py
+++ b/orbkit/qcinfo.py
@@ -28,7 +28,7 @@ from os import path
 from copy import copy
 
 from orbkit.display import display
-from .units import u2me, aa2a0
+from .units import u_to_me, aa_to_a0
 from orbkit.read.tools import get_atom_symbol, standard_mass
 from .orbitals import AOClass, MOClass
 
@@ -106,7 +106,7 @@ class QCinfo:
     self.geo_info = numpy.array(self.geo_info)
     self.geo_spec = numpy.array(self.geo_spec,dtype=float)
     if is_angstrom:
-      self.geo_spec *= aa2a0
+      self.geo_spec *= aa_to_a0
 
   def get_com(self,nuc_list=None):
     '''Computes the center of mass.

--- a/orbkit/read/cclib_parser.py
+++ b/orbkit/read/cclib_parser.py
@@ -2,9 +2,9 @@ import numpy
 
 from orbkit.qcinfo import QCinfo
 from orbkit.orbitals import AOClass, MOClass
-from orbkit.units import aa2a0
+from orbkit.units import aa_to_a0
 from orbkit.core import l_deg, lquant
-from orbkit.units import ev2ha
+from orbkit.units import ev_to_ha
 from importlib import import_module
 
 from .tools import get_atom_symbol
@@ -78,7 +78,7 @@ def convert_cclib(ccData, all_mo=False, spin=None):
   qc.mo_spec = MOClass([])
   
   # Converting all information concerning atoms and geometry
-  qc.geo_spec = ccData.atomcoords[0] * aa2a0
+  qc.geo_spec = ccData.atomcoords[0] * aa_to_a0
   for ii in range(ccData.natom):
     symbol = get_atom_symbol(atom=ccData.atomnos[ii])
     qc.geo_info.append([symbol,str(ii+1),str(ccData.atomnos[ii])])
@@ -184,7 +184,7 @@ def convert_cclib(ccData, all_mo=False, spin=None):
         occ_num = 0.0
         
       qc.mo_spec.append({'coeffs': (ccData.nocoeffs if is_natorb else ccData.mocoeffs[i])[ii],
-              'energy': 0.0 if is_natorb else ccData.moenergies[i][ii]*ev2ha,
+              'energy': 0.0 if is_natorb else ccData.moenergies[i][ii]*ev_to_ha,
               'occ_num': occ_num,
               'sym': '%d.%s' %(sym[a],a)
               })

--- a/orbkit/read/tools.py
+++ b/orbkit/read/tools.py
@@ -8,7 +8,7 @@ import numpy
 
 from orbkit.display import display
 from orbkit.tools import *
-from orbkit.units import u2me
+from orbkit.units import u_to_me
 from orbkit import options
 from orbkit import analytical_integrals
 
@@ -117,9 +117,9 @@ def standard_mass(atom):
     read_nist()  
   try:
     atom = int(atom) - 1
-    return nist_mass[atom][1] * u2me
+    return nist_mass[atom][1] * u_to_me
   except ValueError:
-    return dict(nist_mass)[atom.title()] * u2me
+    return dict(nist_mass)[atom.title()] * u_to_me
     
 def get_atom_symbol(atom):
   '''Returns the atomic symbol of a given atom.

--- a/orbkit/test/units.py
+++ b/orbkit/test/units.py
@@ -5,19 +5,19 @@ from orbkit.units import *
 from orbkit.test.tools import equal
 
 #Reference values for conversion
-ref_ha2ev = 27.211386
-ref_a02aa = 0.529177210
-ref_debye2ea0 = 0.393456
-ref_u2me = 1822.888486192
+ref_ha_to_ev = 27.211386
+ref_a0_to_aa = 0.529177210
+ref_debye_to_ea0 = 0.393456
+ref_u_to_me = 1822.888486192
 
-equal(ha2ev * ev2ha, 1)
-equal(a02aa * aa2a0, 1)
-equal(debye2ea0 * ea02debye, 1)
-equal(u2me * me2u, 1)
+equal(ha_to_ev * ev_to_ha, 1)
+equal(a0_to_aa * aa_to_a0, 1)
+equal(debye_to_ea0 * ea0_to_debye, 1)
+equal(u_to_me * me_to_u, 1)
 
-equal(ha2ev, ref_ha2ev)
-equal(a02aa, ref_a02aa)
-equal(u2me, ref_u2me)
+equal(ha_to_ev, ref_ha_to_ev)
+equal(a0_to_aa, ref_a0_to_aa)
+equal(u_to_me, ref_u_to_me)
 
 #Debye vaue is not precise enouth - test less stringently
-equal(debye2ea0, ref_debye2ea0 , 1e-3)
+equal(debye_to_ea0, ref_debye_to_ea0 , 1e-3)

--- a/orbkit/units.py
+++ b/orbkit/units.py
@@ -24,14 +24,14 @@ _statC = 1. / 2997924580 #Statcoulomb
 _debye = 1e-20*_statC # Debye
                                                                         
 #Conversion factors                                                     
-a02aa = _a0 / _aa                                                       
-aa2a0 = _aa / _a0                                                       
+a0_to_aa = _a0 / _aa                                                       
+aa_to_a0 = _aa / _a0                                                       
                                                                         
-u2me = _u / _me
-me2u = _me / _u                                                        
+u_to_me = _u / _me
+me_to_u = _me / _u                                                        
                                                                         
-ev2ha = _e / _ha
-ha2ev = _ha / _e 
+ev_to_ha = _e / _ha
+ha_to_ev = _ha / _e 
 
-debye2ea0 = _debye / (_e * _a0)
-ea02debye = _e * _a0 / _debye
+debye_to_ea0 = _debye / (_e * _a0)
+ea0_to_debye = _e * _a0 / _debye


### PR DESCRIPTION
  - Conversion factors are now named X_to_Y instead of X2Y to be in line
    with naming conventions in the MO and AO classes.