### PR TITLE
support for capital letters in Molden file

### DIFF
--- a/orbkit/read.py
+++ b/orbkit/read.py
@@ -291,7 +291,7 @@ def read_molden(filename, all_mo=False, spin=None, i_md=-1, interactive=True,
             # AO information section 
             # Initialize a new dict for this AO 
             ao_num = 0               # Initialize number of atomic orbiatls 
-            ao_type = thisline[0]    # Which type of atomic orbital do we have
+            ao_type = thisline[0].lower()    # Which type of atomic orbital do we have
             pnum = int(thisline[1])  # Number of primatives
             # Calculate the degeneracy of this AO and increase basis_count 
             for i_ao in ao_type:


### PR DESCRIPTION
This is just a small bugfix for cases where the type of orbital (S,P,D, ...) is specified as a capital letter in the Molden file.

For example:

~~~~
[GTO]
1    0
S    5    1.000000
   1.23840169E+03    5.45688000E-03
   1.86290050E+02    4.06384100E-02
   4.22511764E+01    1.80255940E-01
   1.16765579E+01    4.63151220E-01
   3.59305065E+00    4.40871730E-01
...
~~~~