### PR TITLE
Fixed bug with view_with_mayavi outdated map call

### DIFF
--- a/orbkit/output.py
+++ b/orbkit/output.py
@@ -760,7 +760,7 @@ def meshgrid2(*arrs):
   http://stackoverflow.com/a/1830192
   '''
   arrs = tuple(reversed(arrs)) 
-  lens = map(len, arrs)
+  lens = list(map(len, arrs))
   dim = len(arrs)
   
   sz = 1


### PR DESCRIPTION
`output.view_with_mayavi` was throwing this error with Python 3.7.3.
```
Traceback (most recent call last):
  File "~/project/pipeline.py", line 109, in pipeline
    output.view_with_mayavi(grid.x, grid.y, grid.z, density)
  File ~/orbkit/orbkit/output.py", line 831, in view_with_mayavi
    Z,Y,X = meshgrid2(z,y,x)
  File "~/orbkit/orbkit/output.py", line 772, in meshgrid2
    slc[i] = lens[i]
TypeError: 'map' object is not subscriptable
```
The issue is that in Python 3 `map` returns an iterator which needs to be converted to a list before it can be indexed into.